### PR TITLE
feat: github actions 自动编译

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,61 @@
+name: hello
+
+on:
+  push:
+    branches:
+    - main
+    - release/*
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+env:
+  OUTPUT_NAME: nqdumpgo
+  MY_BUILD_CONFS: windows-amd64 darwin-amd64 darwin-arm64
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.17.0'
+
+      - name: check deps
+        run: |
+          go version
+
+      - name: build
+        run: |
+          mkdir build
+          cd build
+          for MY_CONF in $MY_BUILD_CONFS
+          do
+            mkdir "$MY_CONF"
+            cd "$MY_CONF"
+            echo GOOS="${MY_CONF%-*}" GOARCH="${MY_CONF#*-}"
+            env GOOS="${MY_CONF%-*}" GOARCH="${MY_CONF#*-}" go build -ldflags="-w -s" "$GITHUB_WORKSPACE"
+            chmod +x *
+            tar -czf "$OUTPUT_NAME-$MY_CONF.tgz" *
+            cd -
+          done
+          find .
+          tar --exclude=**/*.tgz -cf "artifact.tar" */
+
+      - name: Upload build result
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifact
+          path: |
+            build/**/*.tar
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            LICENSE
+            **/*.tgz


### PR DESCRIPTION
增加自动编译，运行时机为：

```yaml
on:
  push:
    branches:
    - main
    - release/*
    tags:
      - "v*.*.*"
  workflow_dispatch:
```

交叉编译配置为：
```yaml
MY_BUILD_CONFS: windows-amd64 darwin-amd64 darwin-arm64
```

流水线编译完成后自动上传到 artifact.zip

tags 编译完成后自动发布 github release
