### PR TITLE
fix: DecodeNCM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/nqdumpgo
+*.exe

--- a/main.go
+++ b/main.go
@@ -201,8 +201,9 @@ func DecodeNCM(name string) bool {
 	checkError(err)
 
 	var tb = make([]byte, n)
+	offset := 0
 	for {
-		_, err := fp.Read(tb)
+		readBytes, err := fp.Read(tb)
 		if err == io.EOF { // read EOF
 			break
 		} else if err != nil {
@@ -210,11 +211,12 @@ func DecodeNCM(name string) bool {
 			fpOut.Close()
 			return false
 		}
-		for i := 0; i < n; i++ {
-			j := byte((i + 1) & 0xff)
+		for i := 0; i < readBytes; i++ {
+			offset += 1
+			j := byte(offset & 0xff)
 			tb[i] ^= box[(box[j]+box[(box[j]+j)&0xff])&0xff]
 		}
-		_, err = fpOut.Write(tb)
+		_, err = fpOut.Write(tb[:readBytes])
 		if err != nil {
 			log.Println(err)
 			fpOut.Close()


### PR DESCRIPTION
# Problem

The output mp3 files fail integrity checking of mpck, due to extraneous file ending.

```bash
$ mpck test/glory\ days.mp3
SUMMARY: test/glory days.mp3
    version                       MPEG v1.0
    layer                         3
    bitrate                       320000 bps
    samplerate                    44100 Hz
    frames                        11258
    time                          4:54.086
    unidentified                  377 b (0%)
    errors                        unidentified bytes
    result                        Bad
```

# Solution

`fp.Read(tb)` does not take up the full buffer, especially when reading near file end.

So only `tb[:readBytes]` should be passed to `fpOut.Write()`.


